### PR TITLE
Add dependabot to Release Drafter chore label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,7 @@ autolabeler:
     - label: 'chore'
       branch:
           - '/chore\/.+/'
+          - '/dependabot\/.+/'
     - label: 'bug'
       branch:
           - '/fix\/.+/'


### PR DESCRIPTION
## Description
Adds the dependabot PRs to automatic categorisation in releases as chores