### PR TITLE
Ensure all rows are ingested into BigQuery properly

### DIFF
--- a/services/analyse/src/Service/Carryforward/CarryforwardTagService.php
+++ b/services/analyse/src/Service/Carryforward/CarryforwardTagService.php
@@ -76,6 +76,13 @@ class CarryforwardTagService implements CarryforwardTagServiceInterface
          */
         $tags = $this->queryService->runQuery(CommitTagsQuery::class, QueryParameterBag::fromUpload($upload));
 
+        if (empty($tags->getCommits())) {
+            // Generally we shouldn't get there, as its a pretty safe assumption that there
+            // should be _at least_ one commit, with one tag (the one we're analysing currently),
+            // however, on the off chance something goes wrong, we should just to double check.
+            return [];
+        }
+
         return $tags->getCommits()[0]->getTags();
     }
 
@@ -136,7 +143,7 @@ class CarryforwardTagService implements CarryforwardTagServiceInterface
             /** @var Tag[] $commitTags */
             $commitTags = array_reduce(
                 $uploadedCommits->getCommits(),
-                static fn (array $tags, CommitQueryResult $result) => $result->getCommit() === $commit ?
+                static fn(array $tags, CommitQueryResult $result) => $result->getCommit() === $commit ?
                     [...$tags, ...$result->getTags()] :
                     $tags,
                 []

--- a/services/ingest/src/Service/Persist/BigQueryPersistService.php
+++ b/services/ingest/src/Service/Persist/BigQueryPersistService.php
@@ -77,18 +77,19 @@ class BigQueryPersistService implements PersistServiceInterface
 
                 $remainingLines--;
 
-                if (
-                    $remainingFiles == 0 &&
-                    $remainingLines == 0
-                ) {
-                    yield $chunk;
-                    return;
-                }
-
                 if (count($chunk) === $chunkSize) {
                     yield $chunk;
                     $chunk = [];
                 }
+            }
+
+            if (
+                !empty($chunk) &&
+                $remainingFiles == 0 &&
+                $remainingLines == 0
+            ) {
+                yield $chunk;
+                return;
             }
         }
     }

--- a/services/ingest/tests/Service/Persist/BigQueryPersistServiceTest.php
+++ b/services/ingest/tests/Service/Persist/BigQueryPersistServiceTest.php
@@ -48,7 +48,7 @@ class BigQueryPersistServiceTest extends TestCase
             ->with(
                 self::callback(
                     static fn(array $rows) => $rows == $expectedInsertedChunks[$insertMatcher->numberOfInvocations(
-                    ) - 1]
+                        ) - 1]
                 )
             )
             ->willReturn($insertResponse);
@@ -101,7 +101,7 @@ class BigQueryPersistServiceTest extends TestCase
             ->with(
                 self::callback(
                     static fn(array $rows) => $rows == $expectedInsertedChunks[$insertMatcher->numberOfInvocations(
-                    ) - 1]
+                        ) - 1]
                 )
             )
             ->willReturn($insertResponse);
@@ -157,7 +157,7 @@ class BigQueryPersistServiceTest extends TestCase
             ->with(
                 self::callback(
                     static fn(array $rows) => $rows == $expectedInsertedChunks[$insertMatcher->numberOfInvocations(
-                    ) - 1]
+                        ) - 1]
                 )
             )
             ->willReturn($insertResponse);
@@ -206,7 +206,7 @@ class BigQueryPersistServiceTest extends TestCase
             new Tag('mock-tag', '')
         );
 
-        for ($numberOfLines = 6; $numberOfLines <= 10; $numberOfLines++) {
+        for ($numberOfLines = 1; $numberOfLines <= 10; $numberOfLines++) {
             $coverage = new Coverage(CoverageFormat::LCOV, 'mock/project/root');
             $expectedInsertedRows = [];
 

--- a/services/ingest/tests/Service/Persist/BigQueryPersistServiceTest.php
+++ b/services/ingest/tests/Service/Persist/BigQueryPersistServiceTest.php
@@ -33,7 +33,7 @@ class BigQueryPersistServiceTest extends TestCase
         Upload $upload,
         Coverage $coverage,
         int $chunkSize,
-        array $expectedInsertedChunks
+        array $expectedChunks
     ): void {
         $insertResponse = $this->createMock(InsertResponse::class);
         $insertResponse->method('isSuccessful')
@@ -42,13 +42,12 @@ class BigQueryPersistServiceTest extends TestCase
             ->willReturn([]);
 
         $mockTable = $this->createMock(Table::class);
-        $insertMatcher = $this->exactly(count($expectedInsertedChunks));
+        $insertMatcher = $this->exactly(count($expectedChunks));
         $mockTable->expects($insertMatcher)
             ->method('insertRows')
             ->with(
                 self::callback(
-                    static fn(array $rows) => $rows == $expectedInsertedChunks[$insertMatcher->numberOfInvocations(
-                        ) - 1]
+                    static fn(array $rows) => $rows == $expectedChunks[$insertMatcher->numberOfInvocations() - 1]
                 )
             )
             ->willReturn($insertResponse);
@@ -86,7 +85,7 @@ class BigQueryPersistServiceTest extends TestCase
         Upload $upload,
         Coverage $coverage,
         int $chunkSize,
-        array $expectedInsertedChunks
+        array $expectedChunks
     ): void {
         $insertResponse = $this->createMock(InsertResponse::class);
         $insertResponse->method('isSuccessful')
@@ -95,13 +94,12 @@ class BigQueryPersistServiceTest extends TestCase
             ->willReturn([]);
 
         $mockTable = $this->createMock(Table::class);
-        $insertMatcher = $this->exactly(count($expectedInsertedChunks));
+        $insertMatcher = $this->exactly(count($expectedChunks));
         $mockTable->expects($insertMatcher)
             ->method('insertRows')
             ->with(
                 self::callback(
-                    static fn(array $rows) => $rows == $expectedInsertedChunks[$insertMatcher->numberOfInvocations(
-                        ) - 1]
+                    static fn(array $rows) => $rows == $expectedChunks[$insertMatcher->numberOfInvocations() - 1]
                 )
             )
             ->willReturn($insertResponse);
@@ -139,7 +137,7 @@ class BigQueryPersistServiceTest extends TestCase
         Upload $upload,
         Coverage $coverage,
         int $chunkSize,
-        array $expectedInsertedChunks
+        array $expectedChunks
     ): void {
         // Add a file to the end, with no lines
         $coverage->addFile(new File('file-with-no-lines'));
@@ -151,13 +149,12 @@ class BigQueryPersistServiceTest extends TestCase
             ->willReturn([]);
 
         $mockTable = $this->createMock(Table::class);
-        $insertMatcher = $this->exactly(count($expectedInsertedChunks));
+        $insertMatcher = $this->exactly(count($expectedChunks));
         $mockTable->expects($insertMatcher)
             ->method('insertRows')
             ->with(
                 self::callback(
-                    static fn(array $rows) => $rows == $expectedInsertedChunks[$insertMatcher->numberOfInvocations(
-                        ) - 1]
+                    static fn(array $rows) => $rows == $expectedChunks[$insertMatcher->numberOfInvocations() - 1]
                 )
             )
             ->willReturn($insertResponse);


### PR DESCRIPTION
## Description
A bug in the BigQuery persist service meant that any coverage files ending with an empty file, would miss some coverage.