### PR TITLE
Correctly use unique line identifier to ensure no overlap between insert Ids in BigQuery

### DIFF
--- a/services/ingest/src/Service/Persist/BigQueryPersistService.php
+++ b/services/ingest/src/Service/Persist/BigQueryPersistService.php
@@ -85,7 +85,7 @@ class BigQueryPersistService implements PersistServiceInterface
                             implode('-', [
                                 $upload->getUploadId(),
                                 $file->getFileName(),
-                                $line->getLineNumber()
+                                $line->getUniqueLineIdentifier()
                             ])
                         ),
                         'data' => $this->bigQueryMetadataBuilderService->buildRow(

--- a/services/ingest/tests/Service/Persist/BigQueryPersistServiceTest.php
+++ b/services/ingest/tests/Service/Persist/BigQueryPersistServiceTest.php
@@ -261,7 +261,7 @@ class BigQueryPersistServiceTest extends TestCase
                             implode('-', [
                                 $upload->getUploadId(),
                                 $file->getFileName(),
-                                $line->getLineNumber()
+                                $line->getUniqueLineIdentifier()
                             ])
                         ),
                         'data' => [


### PR DESCRIPTION
## Description