### PR TITLE
Use existing uploaded tags for carryforward behaviour

### DIFF
--- a/services/analyse/src/Model/PublishableCoverageData.php
+++ b/services/analyse/src/Model/PublishableCoverageData.php
@@ -19,7 +19,6 @@ use App\Service\Diff\DiffParserServiceInterface;
 use App\Service\QueryService;
 use DateTimeImmutable;
 use Packages\Models\Model\Event\EventInterface;
-use Packages\Models\Model\Event\Upload;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 class PublishableCoverageData implements PublishableCoverageDataInterface
@@ -79,7 +78,10 @@ class PublishableCoverageData implements PublishableCoverageDataInterface
         $params = QueryParameterBag::fromEvent($this->event);
         $params->set(
             QueryParameter::CARRYFORWARD_TAGS,
-            $this->carryforwardTagService->getTagsToCarryforward($this->event)
+            $this->carryforwardTagService->getTagsToCarryforward(
+                $this->event,
+                $this->getUploads()->getSuccessfulTags()
+            )
         );
         $params->set(
             QueryParameter::UPLOADS_SCOPE,
@@ -100,7 +102,10 @@ class PublishableCoverageData implements PublishableCoverageDataInterface
         $params = QueryParameterBag::fromEvent($this->event);
         $params->set(
             QueryParameter::CARRYFORWARD_TAGS,
-            $this->carryforwardTagService->getTagsToCarryforward($this->event)
+            $this->carryforwardTagService->getTagsToCarryforward(
+                $this->event,
+                $this->getUploads()->getSuccessfulTags()
+            )
         );
         $params->set(
             QueryParameter::UPLOADS_SCOPE,
@@ -121,7 +126,10 @@ class PublishableCoverageData implements PublishableCoverageDataInterface
         $params = QueryParameterBag::fromEvent($this->event);
         $params->set(
             QueryParameter::CARRYFORWARD_TAGS,
-            $this->carryforwardTagService->getTagsToCarryforward($this->event)
+            $this->carryforwardTagService->getTagsToCarryforward(
+                $this->event,
+                $this->getUploads()->getSuccessfulTags()
+            )
         );
         $params->set(
             QueryParameter::UPLOADS_SCOPE,
@@ -142,7 +150,10 @@ class PublishableCoverageData implements PublishableCoverageDataInterface
         $params = QueryParameterBag::fromEvent($this->event);
         $params->set(
             QueryParameter::CARRYFORWARD_TAGS,
-            $this->carryforwardTagService->getTagsToCarryforward($this->event)
+            $this->carryforwardTagService->getTagsToCarryforward(
+                $this->event,
+                $this->getUploads()->getSuccessfulTags()
+            )
         );
         $params->set(
             QueryParameter::UPLOADS_SCOPE,
@@ -163,7 +174,10 @@ class PublishableCoverageData implements PublishableCoverageDataInterface
         $params = QueryParameterBag::fromEvent($this->event);
         $params->set(
             QueryParameter::CARRYFORWARD_TAGS,
-            $this->carryforwardTagService->getTagsToCarryforward($this->event)
+            $this->carryforwardTagService->getTagsToCarryforward(
+                $this->event,
+                $this->getUploads()->getSuccessfulTags()
+            )
         );
         $params->set(
             QueryParameter::UPLOADS_SCOPE,
@@ -188,7 +202,10 @@ class PublishableCoverageData implements PublishableCoverageDataInterface
         );
         $params->set(
             QueryParameter::CARRYFORWARD_TAGS,
-            $this->carryforwardTagService->getTagsToCarryforward($this->event)
+            $this->carryforwardTagService->getTagsToCarryforward(
+                $this->event,
+                $this->getUploads()->getSuccessfulTags()
+            )
         );
         $params->set(
             QueryParameter::UPLOADS_SCOPE,
@@ -220,7 +237,10 @@ class PublishableCoverageData implements PublishableCoverageDataInterface
         );
         $params->set(
             QueryParameter::CARRYFORWARD_TAGS,
-            $this->carryforwardTagService->getTagsToCarryforward($this->event)
+            $this->carryforwardTagService->getTagsToCarryforward(
+                $this->event,
+                $this->getUploads()->getSuccessfulTags()
+            )
         );
         $params->set(
             QueryParameter::UPLOADS_SCOPE,
@@ -247,7 +267,10 @@ class PublishableCoverageData implements PublishableCoverageDataInterface
         );
         $params->set(
             QueryParameter::CARRYFORWARD_TAGS,
-            $this->carryforwardTagService->getTagsToCarryforward($this->event)
+            $this->carryforwardTagService->getTagsToCarryforward(
+                $this->event,
+                $this->getUploads()->getSuccessfulTags()
+            )
         );
         $params->set(
             QueryParameter::UPLOADS_SCOPE,

--- a/services/analyse/src/Query/Result/TotalUploadsQueryResult.php
+++ b/services/analyse/src/Query/Result/TotalUploadsQueryResult.php
@@ -4,28 +4,43 @@ namespace App\Query\Result;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use Packages\Models\Model\Tag;
 
 class TotalUploadsQueryResult implements QueryResultInterface
 {
     /**
      * @param string[] $successfulUploads
+     * @param Tag[] $successfulTags
      * @param string[] $pendingUploads
      */
     private function __construct(
         private readonly array $successfulUploads,
+        private readonly array $successfulTags,
         private readonly array $pendingUploads,
         private readonly ?DateTimeImmutable $latestSuccessfulUpload
     ) {
     }
 
     public static function from(
+        string $commit,
         array $successfulUploads,
+        array $successfulTags,
         array $pendingUploads,
         ?string $latestSuccessfulUpload = null
     ): self {
         return new self(
-            array_filter($successfulUploads, static fn(mixed $uploadId) => is_string($uploadId)),
-            array_filter($pendingUploads, static fn(mixed $uploadId) => is_string($uploadId)),
+            array_filter(
+                $successfulUploads,
+                static fn(mixed $uploadId) => is_string($uploadId)
+            ),
+            array_map(
+                static fn(string $tag) => new Tag($tag, $commit),
+                array_filter($successfulTags, static fn(mixed $tag) => is_string($tag))
+            ),
+            array_filter(
+                $pendingUploads,
+                static fn(mixed $uploadId) => is_string($uploadId)
+            ),
             $latestSuccessfulUpload ? (DateTimeImmutable::createFromFormat(
                 DateTimeInterface::ATOM,
                 $latestSuccessfulUpload
@@ -36,6 +51,14 @@ class TotalUploadsQueryResult implements QueryResultInterface
     public function getSuccessfulUploads(): array
     {
         return $this->successfulUploads;
+    }
+
+    /**
+     * @return Tag[]
+     */
+    public function getSuccessfulTags(): array
+    {
+        return $this->successfulTags;
     }
 
     public function getPendingUploads(): array

--- a/services/analyse/src/Service/Carryforward/CachingCarryforwardTagService.php
+++ b/services/analyse/src/Service/Carryforward/CachingCarryforwardTagService.php
@@ -9,9 +9,9 @@ use WeakMap;
 
 class CachingCarryforwardTagService implements CarryforwardTagServiceInterface
 {
-    private const EXISTING_TAGS_CACHE_PARAM = "existingTags";
+    private const EXISTING_TAGS_CACHE_PARAM = 'existingTags';
 
-    private const RESULT_CACHE_PARAM = "result";
+    private const RESULT_CACHE_PARAM = 'result';
 
     /**
      * @var WeakMap<EventInterface, array{ existingTags: Tag[], result: Tag[] }[]>

--- a/services/analyse/src/Service/Carryforward/CarryforwardTagServiceInterface.php
+++ b/services/analyse/src/Service/Carryforward/CarryforwardTagServiceInterface.php
@@ -11,7 +11,8 @@ interface CarryforwardTagServiceInterface
      * Identify any tags which need to be carried forward from previous commits,
      * because they have not (yet) been uploaded to the current commit.
      *
+     * @param Tag[] $existingTags
      * @return Tag[]
      */
-    public function getTagsToCarryforward(EventInterface $event): array;
+    public function getTagsToCarryforward(EventInterface $event, array $existingTags): array;
 }

--- a/services/analyse/tests/Model/CachingPublishableCoverageDataTest.php
+++ b/services/analyse/tests/Model/CachingPublishableCoverageDataTest.php
@@ -45,7 +45,9 @@ class CachingPublishableCoverageDataTest extends TestCase
     public function testGetUploads(): void
     {
         $result = TotalUploadsQueryResult::from(
+            'mock-commit',
             ['a'],
+            ['c'],
             ['b'],
             '2023-09-09T01:22:00+0000'
         );
@@ -71,7 +73,9 @@ class CachingPublishableCoverageDataTest extends TestCase
     public function testGetSuccessfulUploads(): void
     {
         $result = TotalUploadsQueryResult::from(
+            'mock-commit',
             ['a'],
+            ['c'],
             ['b'],
             '2023-09-09T01:22:00+0000'
         );
@@ -97,7 +101,9 @@ class CachingPublishableCoverageDataTest extends TestCase
     public function testGetPendingUploads(): void
     {
         $result = TotalUploadsQueryResult::from(
+            'mock-commit',
             ['a'],
+            ['c'],
             ['b'],
             '2023-09-09T01:22:00+0000'
         );
@@ -123,7 +129,9 @@ class CachingPublishableCoverageDataTest extends TestCase
     public function testGetLatestSuccessfulUpload(): void
     {
         $result = TotalUploadsQueryResult::from(
+            'mock-commit',
             ['a'],
+            ['c'],
             ['b'],
             '2023-09-09T01:22:00+0000'
         );
@@ -151,7 +159,7 @@ class CachingPublishableCoverageDataTest extends TestCase
         $this->mockQueryService->expects($this->exactly(2))
             ->method('runQuery')
             ->willReturnOnConsecutiveCalls(
-                TotalUploadsQueryResult::from(['mock-upload'], []),
+                TotalUploadsQueryResult::from('mock-commit', ['mock-upload'], ['tag-1'], []),
                 CoverageQueryResult::from([
                     'lines' => 6,
                     'covered' => 1,
@@ -174,7 +182,7 @@ class CachingPublishableCoverageDataTest extends TestCase
         $this->mockQueryService->expects($this->exactly(2))
             ->method('runQuery')
             ->willReturnOnConsecutiveCalls(
-                TotalUploadsQueryResult::from(['mock-upload'], []),
+                TotalUploadsQueryResult::from('mock-commit', ['mock-upload'], ['tag-1'], []),
                 CoverageQueryResult::from([
                     'lines' => 6,
                     'covered' => 1,
@@ -197,7 +205,7 @@ class CachingPublishableCoverageDataTest extends TestCase
         $this->mockQueryService->expects($this->exactly(2))
             ->method('runQuery')
             ->willReturnOnConsecutiveCalls(
-                TotalUploadsQueryResult::from(['mock-upload'], []),
+                TotalUploadsQueryResult::from('mock-commit', ['mock-upload'], ['tag-1'], []),
                 CoverageQueryResult::from([
                     'lines' => 6,
                     'covered' => 1,
@@ -220,7 +228,7 @@ class CachingPublishableCoverageDataTest extends TestCase
         $this->mockQueryService->expects($this->exactly(2))
             ->method('runQuery')
             ->willReturnOnConsecutiveCalls(
-                TotalUploadsQueryResult::from(['mock-upload'], []),
+                TotalUploadsQueryResult::from('mock-commit', ['mock-upload'], ['tag-1'], []),
                 CoverageQueryResult::from([
                     'lines' => 6,
                     'covered' => 1,
@@ -255,7 +263,7 @@ class CachingPublishableCoverageDataTest extends TestCase
         $this->mockQueryService->expects($this->exactly(2))
             ->method('runQuery')
             ->willReturnOnConsecutiveCalls(
-                TotalUploadsQueryResult::from(['mock-upload'], []),
+                TotalUploadsQueryResult::from('mock-commit', ['mock-upload'], ['tag-1'], []),
                 $files
             );
 
@@ -272,7 +280,7 @@ class CachingPublishableCoverageDataTest extends TestCase
         $this->mockQueryService->expects($this->exactly(2))
             ->method('runQuery')
             ->willReturnOnConsecutiveCalls(
-                TotalUploadsQueryResult::from(['mock-upload'], []),
+                TotalUploadsQueryResult::from('mock-commit', ['mock-upload'], ['tag-1'], []),
                 CoverageQueryResult::from([
                     'lines' => 6,
                     'covered' => 1,
@@ -306,7 +314,7 @@ class CachingPublishableCoverageDataTest extends TestCase
         $this->mockQueryService->expects($this->exactly(2))
             ->method('runQuery')
             ->willReturnOnConsecutiveCalls(
-                TotalUploadsQueryResult::from(['mock-upload'], []),
+                TotalUploadsQueryResult::from('mock-commit', ['mock-upload'], ['tag-1'], []),
                 $files
             );
 
@@ -331,7 +339,7 @@ class CachingPublishableCoverageDataTest extends TestCase
         $this->mockQueryService->expects($this->exactly(2))
             ->method('runQuery')
             ->willReturnOnConsecutiveCalls(
-                TotalUploadsQueryResult::from(['mock-upload'], []),
+                TotalUploadsQueryResult::from('mock-commit', ['mock-upload'], ['tag-1'], []),
                 $lines
             );
 

--- a/services/analyse/tests/Query/TotalUploadsQueryTest.php
+++ b/services/analyse/tests/Query/TotalUploadsQueryTest.php
@@ -25,6 +25,8 @@ class TotalUploadsQueryTest extends AbstractQueryTestCase
               uploads AS (
                 SELECT
                   uploadId,
+                  tag,
+                  commit,
                   IF(
                     COUNT(uploadId) >= totalLines,
                     1,
@@ -45,13 +47,19 @@ class TotalUploadsQueryTest extends AbstractQueryTestCase
                   AND provider = "github"
                 GROUP BY
                   uploadId,
+                  tag,
+                  commit,
                   totalLines,
                   ingestTime
               )
             SELECT
+              ANY_VALUE(commit) as commit,
               ARRAY_AGG(
                 IF(successful = 1, uploadId, NULL) IGNORE NULLS
               ) as successfulUploads,
+              ARRAY_AGG(
+                IF(successful = 1, tag, NULL) IGNORE NULLS
+              ) as successfulTags,
               ARRAY_AGG(
                 IF(pending = 1, uploadId, NULL) IGNORE NULLS
               ) as pendingUploads,
@@ -108,35 +116,45 @@ class TotalUploadsQueryTest extends AbstractQueryTestCase
         return [
             [
                 [
+                    'commit' => 'mock-commit',
                     'successfulUploads' => ['1'],
+                    'successfulTags' => ['tag-1'],
                     'pendingUploads' => [],
                     'latestSuccessfulUpload' => new DateTime('2023-09-09T12:00:00+0000')
                 ]
             ],
             [
                 [
+                    'commit' => 'mock-commit',
                     'successfulUploads' => ['1', '2'],
+                    'successfulTags' => ['tag-1', 'tag-2'],
                     'pendingUploads' => ['3'],
                     'latestSuccessfulUpload' => new DateTime('2023-09-09T12:00:00+0000')
                 ]
             ],
             [
                 [
+                    'commit' => 'mock-commit',
                     'successfulUploads' => ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
+                    'successfulTags' => ['tag-1'],
                     'pendingUploads' => [],
                     'latestSuccessfulUpload' => new DateTime('2023-09-09T12:00:00+0000')
                 ],
             ],
             [
                 [
+                    'commit' => 'mock-commit',
                     'successfulUploads' => ['1', '2', '3', '4', '5', '6', '7', '8'],
+                    'successfulTags' => ['tag-1'],
                     'pendingUploads' => ['9', '10'],
                     'latestSuccessfulUpload' => new DateTime('2023-09-09T12:00:00+0000')
                 ]
             ],
             [
                 [
+                    'commit' => 'mock-commit',
                     'successfulUploads' => [],
+                    'successfulTags' => [],
                     'pendingUploads' => ['9', '10'],
                     'latestSuccessfulUpload' => null
                 ]

--- a/services/analyse/tests/Service/Carryforward/CachingCarryforwardTagServiceTest.php
+++ b/services/analyse/tests/Service/Carryforward/CachingCarryforwardTagServiceTest.php
@@ -12,25 +12,35 @@ class CachingCarryforwardTagServiceTest extends TestCase
 {
     public function testCachesRepeatedRequests(): void
     {
-        $tags = [new Tag('tag', 'commit')];
+        $carryforwardTags = [new Tag('tag', 'commit')];
 
         $mockCarryforwardTagService = $this->createMock(CarryforwardTagService::class);
 
         $mockCarryforwardTagService->expects($this->once())
             ->method('getTagsToCarryforward')
-            ->willReturn($tags);
+            ->willReturn($carryforwardTags);
 
         $cachingCarryforwardTagService = new CachingCarryforwardTagService($mockCarryforwardTagService);
 
         $mockUpload = $this->createMock(Upload::class);
 
         $this->assertEquals(
-            $tags,
-            $cachingCarryforwardTagService->getTagsToCarryforward($mockUpload)
+            $carryforwardTags,
+            $cachingCarryforwardTagService->getTagsToCarryforward(
+                $mockUpload,
+                [
+                    new Tag('tag', 'commit')
+                ]
+            )
         );
         $this->assertEquals(
-            $tags,
-            $cachingCarryforwardTagService->getTagsToCarryforward($mockUpload)
+            $carryforwardTags,
+            $cachingCarryforwardTagService->getTagsToCarryforward(
+                $mockUpload,
+                [
+                    new Tag('tag', 'commit')
+                ]
+            )
         );
     }
 
@@ -49,13 +59,15 @@ class CachingCarryforwardTagServiceTest extends TestCase
         $this->assertEquals(
             $tags,
             $cachingCarryforwardTagService->getTagsToCarryforward(
-                $this->createMock(Upload::class)
+                $this->createMock(Upload::class),
+                [new Tag('tag', 'commit')]
             )
         );
         $this->assertEquals(
             $tags,
             $cachingCarryforwardTagService->getTagsToCarryforward(
-                $this->createMock(Upload::class)
+                $this->createMock(Upload::class),
+                [new Tag('tag', 'commit')]
             )
         );
     }

--- a/services/analyse/tests/Service/Carryforward/CarryforwardTagServiceTest.php
+++ b/services/analyse/tests/Service/Carryforward/CarryforwardTagServiceTest.php
@@ -49,15 +49,9 @@ class CarryforwardTagServiceTest extends TestCase
             new Tag('mock-tag', 'mock-commit-1')
         );
 
-        $mockQueryService->expects($this->exactly(2))
+        $mockQueryService->expects($this->once())
             ->method('runQuery')
-            ->willReturnOnConsecutiveCalls(
-                CommitCollectionQueryResult::from([
-                    [
-                        'commit' => 'mock-commit-1',
-                        'tags' => ['tag-4']
-                    ],
-                ]),
+            ->willReturn(
                 CommitCollectionQueryResult::from([
                     [
                         'commit' => 'mock-commit-2',
@@ -78,7 +72,12 @@ class CarryforwardTagServiceTest extends TestCase
                 ])
             );
 
-        $tags = $carryforwardTagService->getTagsToCarryforward($upload);
+        $tags = $carryforwardTagService->getTagsToCarryforward(
+            $upload,
+            [
+                new Tag('tag-4', 'mock-commit-1')
+            ]
+        );
 
         $this->assertEquals(
             [
@@ -114,18 +113,16 @@ class CarryforwardTagServiceTest extends TestCase
             new Tag('mock-tag', 'mock-commit-1')
         );
 
-        $mockQueryService->expects($this->once())
-            ->method('runQuery')
-            ->willReturnOnConsecutiveCalls(
-                CommitCollectionQueryResult::from([
-                    [
-                        'commit' => 'mock-commit-1',
-                        'tags' => ['tag-4', 'tag-2']
-                    ],
-                ])
-            );
+        $mockQueryService->expects($this->never())
+            ->method('runQuery');
 
-        $tags = $carryforwardTagService->getTagsToCarryforward($upload);
+        $tags = $carryforwardTagService->getTagsToCarryforward(
+            $upload,
+            [
+                new Tag('tag-4', 'mock-commit-1'),
+                new Tag('tag-2', 'mock-commit-1'),
+            ]
+        );
 
         $this->assertEquals(
             [],
@@ -168,13 +165,9 @@ class CarryforwardTagServiceTest extends TestCase
             new Tag('mock-tag', 'mock-commit-1')
         );
 
-        // This shouldn't really happen (no current tags), as the upload we're analysing currently
-        // should _always_ be in BigQuery, but we should handle it gracefully if something goes wrong
-        // during BigQuery persistence.
-        $mockQueryService->expects($this->exactly(2))
+        $mockQueryService->expects($this->once())
             ->method('runQuery')
-            ->willReturnOnConsecutiveCalls(
-                CommitCollectionQueryResult::from([]),
+            ->willReturn(
                 CommitCollectionQueryResult::from([
                     [
                         'commit' => 'mock-commit-2',
@@ -195,7 +188,10 @@ class CarryforwardTagServiceTest extends TestCase
                 ])
             );
 
-        $tags = $carryforwardTagService->getTagsToCarryforward($upload);
+        // This shouldn't really happen (no current tags), as the upload we're analysing currently
+        // should _always_ be in BigQuery, but we should handle it gracefully if something goes wrong
+        // during BigQuery persistence.
+        $tags = $carryforwardTagService->getTagsToCarryforward($upload, []);
 
         $this->assertEquals(
             [

--- a/services/analyse/tests/Service/QueryServiceTest.php
+++ b/services/analyse/tests/Service/QueryServiceTest.php
@@ -246,7 +246,7 @@ class QueryServiceTest extends TestCase
             ],
             'Total commit uploads query' => [
                 TotalUploadsQuery::class,
-                TotalUploadsQueryResult::from(['1', '2'], ['3'])
+                TotalUploadsQueryResult::from('mock-commit', ['1', '2'], ['tag-1'], ['3'])
             ],
             'Diff coverage query' => [
                 LineCoverageQuery::class,


### PR DESCRIPTION
## Description
Concurrent uploads can cause a minor race condition in the carryforward logic - a tag can be carried forward while simultaneously also included from the current commits uploads because the carryforward queries were running before the results used for publishing.