### PR TITLE
Limit tag availability to 90 days to avoid excessive commit history depth

### DIFF
--- a/services/analyse/src/Query/TagAvailabilityQuery.php
+++ b/services/analyse/src/Query/TagAvailabilityQuery.php
@@ -23,6 +23,14 @@ class TagAvailabilityQuery implements QueryInterface
     use UploadTableAwareTrait;
     use ScopeAwareTrait;
 
+    /**
+     * The maximum days we'll consider a tag as being available for.
+     *
+     * This influences how long we look back in the commit history when
+     * carrying forward tags from older commits.
+     */
+    private const int MAXIMUM_TAG_AGE_DAYS = 90;
+
     public function __construct(
         private readonly SerializerInterface&DenormalizerInterface $serializer,
         #[Autowire(service: EnvironmentService::class)]
@@ -33,6 +41,7 @@ class TagAvailabilityQuery implements QueryInterface
     public function getQuery(string $table, ?QueryParameterBag $parameterBag = null): string
     {
         $repositoryScope = self::getRepositoryScope($parameterBag);
+        $maximumTagAge = self::MAXIMUM_TAG_AGE_DAYS;
 
         return <<<SQL
         SELECT
@@ -41,6 +50,9 @@ class TagAvailabilityQuery implements QueryInterface
         FROM
           `{$table}`
         WHERE
+            -- Only include uploads on tags which are recent. That way we can avoid permanently
+            -- looking for tags deep in the commit history which are obsolete/no longer uploaded.
+            ingestTime > CAST(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {$maximumTagAge} DAY) as DATETIME) AND
             {$repositoryScope}
         GROUP BY
           tag

--- a/services/analyse/tests/Query/AbstractQueryTestCase.php
+++ b/services/analyse/tests/Query/AbstractQueryTestCase.php
@@ -39,9 +39,9 @@ abstract class AbstractQueryTestCase extends KernelTestCase
                     repository: 'mock-repository',
                     ref: 'mock-ref',
                     commit: 'mock-commit',
-                    pullRequest: 12,
                     history: [],
-                    diff: []
+                    diff: [],
+                    pullRequest: 12
                 )
             )
         ];

--- a/services/analyse/tests/Query/TagAvailabilityQueryTest.php
+++ b/services/analyse/tests/Query/TagAvailabilityQueryTest.php
@@ -28,7 +28,15 @@ class TagAvailabilityQueryTest extends AbstractQueryTestCase
             FROM
               `mock-table`
             WHERE
-              repository = "mock-repository"
+              -- Only include uploads on tags which are recent. That way we can avoid permanently
+              -- looking for tags deep in the commit history which are obsolete/no longer uploaded.
+              ingestTime > CAST(
+                TIMESTAMP_SUB(
+                  CURRENT_TIMESTAMP(),
+                  INTERVAL 90 DAY
+                ) as DATETIME
+              )
+              AND repository = "mock-repository"
               AND owner = "mock-owner"
               AND provider = "github"
             GROUP BY


### PR DESCRIPTION
## Description