### PR TITLE
[Part 7] Use comparable commits to save unnecessary requests to history service

### DIFF
--- a/services/analyse/src/Model/ReportWaypoint.php
+++ b/services/analyse/src/Model/ReportWaypoint.php
@@ -10,11 +10,13 @@ class ReportWaypoint implements Stringable
 {
     /**
      *  @param Closure(ReportWaypoint $waypoint, int $page):array{
-     *      commit: string,
-     *      isOnBaseRef: bool
+     *     commit: string,
+     *     merged: bool,
+     *     ref: string|null
      *  }[]|array{
-     *      commit: string,
-     *      isOnBaseRef: bool
+     *     commit: string,
+     *     merged: bool,
+     *     ref: string|null
      *  }[] $history
      *  @param Closure(ReportWaypoint $waypoint):array<string, array<int, int>>|array<string, array<int, int>> $diff
      */
@@ -61,10 +63,7 @@ class ReportWaypoint implements Stringable
     }
 
     /**
-     * @return array{
-     *     commit: string,
-     *     isOnBaseRef: bool
-     * }[]
+     * @return array{commit: string, merged: bool, ref: string|null}[]
      */
     public function getHistory(int $page = 1): array
     {

--- a/services/analyse/src/Service/CoverageAnalyserService.php
+++ b/services/analyse/src/Service/CoverageAnalyserService.php
@@ -437,7 +437,7 @@ class CoverageAnalyserService implements CoverageAnalyserServiceInterface
     }
 
     /**
-     * @return array{commit: string, isOnBaseRef: bool}[]
+     * @return array{commit: string, merged: bool, ref: string|null}[]
      */
     protected function getHistory(ReportWaypoint $waypoint, int $page = 1): array
     {

--- a/services/analyse/src/Service/Event/UploadsFinalisedEventProcessor.php
+++ b/services/analyse/src/Service/Event/UploadsFinalisedEventProcessor.php
@@ -212,7 +212,7 @@ class UploadsFinalisedEventProcessor implements EventProcessorInterface
                 $history = $headWaypoint->getHistory($page);
 
                 foreach ($history as $commit) {
-                    if ($commit['isOnBaseRef']) {
+                    if ($commit['ref'] !== $headWaypoint->getRef() || $commit['merged']) {
                         $this->eventProcessorLogger->info(
                             sprintf(
                                 'Extracted %s from history to use as the base commit for comparison to %s',

--- a/services/analyse/src/Service/History/CachingCommitHistoryService.php
+++ b/services/analyse/src/Service/History/CachingCommitHistoryService.php
@@ -114,7 +114,7 @@ class CachingCommitHistoryService extends CommitHistoryService
                 ) {
                     // We've populated the page we're looking for, so we can switch to that page
                     // with no additional overhead
-                    $cachedPage = $cachedPage + $pageOffset;
+                    $cachedPage += $pageOffset;
                     $cachedCommits = $this->getPrecedingCommits($cachedWaypoint, $cachedPage);
                 } elseif ($pageOffset > 0) {
                     // The page we want is not yet populated. We could populate it, but that would _increase_
@@ -151,14 +151,14 @@ class CachingCommitHistoryService extends CommitHistoryService
                 if ($this->isPageFullyPopulated($cachedCommits)) {
                     // The page we're looking for is fully populated, meaning there may be
                     // more commits in the history we've not yet seen.
-                    $usableCachedCommits = array_merge(
-                        $usableCachedCommits,
-                        array_slice(
+                    $usableCachedCommits = [
+                        ...$usableCachedCommits,
+                        ...array_slice(
                             $this->getPrecedingCommits($cachedWaypoint, $cachedPage + 1),
                             0,
                             CommitHistoryService::COMMITS_TO_RETURN_PER_PAGE - count($usableCachedCommits)
                         )
-                    );
+                    ];
 
                     $this->commitHistoryLogger->info(
                         sprintf(

--- a/services/analyse/src/Service/History/CachingCommitHistoryService.php
+++ b/services/analyse/src/Service/History/CachingCommitHistoryService.php
@@ -84,8 +84,10 @@ class CachingCommitHistoryService extends CommitHistoryService
      */
     private function tryPopulatingCacheFromComparableWaypoints(ReportWaypoint $waypoint, int $page): void
     {
+        /** @var array<int, array{commit: string, merged: bool, ref: string|null}[]> $history */
         foreach ($this->cache as $cachedWaypoint => $history) {
             if (
+                !$cachedWaypoint instanceof ReportWaypoint ||
                 $cachedWaypoint === $waypoint ||
                 !$cachedWaypoint->comparable($waypoint)
             ) {
@@ -209,6 +211,8 @@ class CachingCommitHistoryService extends CommitHistoryService
 
     /**
      * Persist a series of commits in the cache for a waypoints page.
+     *
+     * @param array{commit: string, merged: bool, ref: string|null}[] $commits
      */
     private function persistInCache(ReportWaypoint $waypoint, int $page, array $commits): void
     {

--- a/services/analyse/src/Service/History/CachingCommitHistoryService.php
+++ b/services/analyse/src/Service/History/CachingCommitHistoryService.php
@@ -10,7 +10,7 @@ use WeakMap;
 class CachingCommitHistoryService extends CommitHistoryService
 {
     /**
-     * @var WeakMap<ReportWaypoint, array<int, array{commit: string, isOnBaseRef: bool}[]>>
+     * @var WeakMap<ReportWaypoint, array<int, array{commit: string, merged: bool, ref: string|null}[]>>
      */
     private WeakMap $cache;
 
@@ -27,7 +27,7 @@ class CachingCommitHistoryService extends CommitHistoryService
         parent::__construct($parsers);
 
         /**
-         * @var WeakMap<ReportWaypoint, array<int, array{commit: string, isOnBaseRef: bool}[]>> $cache
+         * @var WeakMap<ReportWaypoint, array<int, array{commit: string, merged: bool, ref: string|null}[]>> $cache
          */
         $cache = new WeakMap();
 
@@ -36,15 +36,128 @@ class CachingCommitHistoryService extends CommitHistoryService
 
     public function getPrecedingCommits(ReportWaypoint $waypoint, int $page = 1): array
     {
-        if (!isset($this->cache[$waypoint][$page])) {
-            $this->cache[$waypoint] = array_replace(
-                $this->cache[$waypoint] ?? [],
-                [
-                    $page => parent::getPrecedingCommits($waypoint, $page)
-                ]
+        if (!$this->isCacheHit($waypoint, $page)) {
+            $this->tryPopulatingCacheFromComparableWaypoints($waypoint, $page);
+        }
+
+        if (!$this->isCacheHit($waypoint, $page)) {
+            $this->persistInCache(
+                $waypoint,
+                $page,
+                parent::getPrecedingCommits($waypoint, $page)
             );
         }
 
         return $this->cache[$waypoint][$page];
+    }
+
+    /**
+     * This method allows our commit history service to be a bit smarter with how
+     * the in memory cache makes use of the history we've already seen.
+     *
+     * Effectively, it uses comparable waypoints which have already been cached (i.e. ones that
+     * exist in the same owner/repository context) to try and populate the cache for the current
+     * waypoint being called.
+     *
+     * Large this is a best effort behaviour, as we can't guarantee that the waypoints will always be
+     * available. However it does allow us to save some computation and request overhead.
+     *
+     * We can do this because of the causal nature of git history, i.e. if a commit is in the history,
+     * we're confident the commits before it will be the same regardless of which point in the tree
+     * we've entered at.
+     *
+     * For example, consider a two comparable waypoints called sequentially
+     * ```
+     * commit-1 <- First waypoint starts here (and is cached)
+     * commit-2
+     * commit-3 <- A different waypoint starts here (and is not cached)
+     * ...
+     * commit-99
+     * ```
+     * In this case we can use the fist waypoints history to populate the cache for the second waypoint
+     * because we know that the commits preceding commit-3 will be the same as the commits preceding
+     * commit-1.
+     */
+    private function tryPopulatingCacheFromComparableWaypoints(ReportWaypoint $waypoint, int $page): void
+    {
+        foreach ($this->cache as $cachedWaypoint => $history) {
+            if (!$cachedWaypoint->comparable($waypoint)) {
+                // This waypoint isn't comparable so definitely doesn't contain
+                // any pre-cached history we can use.
+                continue;
+            }
+
+            foreach ($history as $cachedPage => $commits) {
+                $commitIndex = array_search(
+                    $waypoint->getCommit(),
+                    array_column($commits, 'commit'),
+                    true
+                );
+
+                if ($commitIndex === false) {
+                    // This waypoint doesn't contain the commit we're looking
+                    // for, so we've not yet seen it in the cache
+                    continue;
+                }
+
+                // We've found the commit we're looking for as the head, so from here
+                // we can populate the cache for the current waypoint
+                $perPage = CommitHistoryService::COMMITS_TO_RETURN_PER_PAGE;
+                $pageOffset = ($page - 1);
+
+                if ($pageOffset > 0 && !$this->isCacheHit($cachedWaypoint, $cachedPage + $pageOffset)) {
+                    // We've not yet populated the cache for the page we're looking for
+                    // so theres not much we can do here
+                    return;
+                }
+
+                $preCachedCommits = array_slice(
+                    $commits,
+                    $commitIndex,
+                    $perPage
+                );
+
+                if (count($preCachedCommits) >= $perPage) {
+                    // Our slice of the existing history is enough to fill the whole
+                    // page, so we're okay to populate the cache and move on
+                    $this->persistInCache($waypoint, $page, $preCachedCommits);
+
+                    break;
+                }
+
+                if (count($commits) >= $perPage) {
+                    // We've not got enough commits to fill the page, so we need to look
+                    // back another page for the cached waypoint and then slice the results
+                    // together
+                    $preCachedCommits = array_merge(
+                        $preCachedCommits,
+                        array_slice(
+                            $this->getPrecedingCommits($cachedWaypoint, $cachedPage + 1),
+                            0,
+                            $perPage - count($preCachedCommits)
+                        )
+                    );
+                }
+
+                $this->persistInCache($waypoint, $page, $preCachedCommits);
+
+                break;
+            }
+        }
+    }
+
+    private function isCacheHit(ReportWaypoint $waypoint, int $page): bool
+    {
+        return isset($this->cache[$waypoint][$page]);
+    }
+
+    private function persistInCache(ReportWaypoint $waypoint, int $page, array $commits): void
+    {
+        $this->cache[$waypoint] = array_replace(
+            $this->cache[$waypoint] ?? [],
+            [
+                $page => $commits
+            ]
+        );
     }
 }

--- a/services/analyse/src/Service/History/CachingCommitHistoryService.php
+++ b/services/analyse/src/Service/History/CachingCommitHistoryService.php
@@ -193,8 +193,8 @@ class CachingCommitHistoryService extends CommitHistoryService
     /**
      * Check if the page is fully populated with commits.
      *
-     * Or, more specifically, see if the number of commits is greater than or equal to the number
-     * we would've tried to fetch to begin with.
+     * Or, more specifically, see if the number of the commits are greater than or equal to
+     * the number we would've tried to fetch to begin with.
      */
     private function isPageFullyPopulated(array $commits): bool
     {

--- a/services/analyse/src/Service/History/CommitHistoryService.php
+++ b/services/analyse/src/Service/History/CommitHistoryService.php
@@ -27,7 +27,7 @@ class CommitHistoryService implements CommitHistoryServiceInterface
     }
 
     /**
-     * @return array{commit: string, isOnBaseRef: bool}[]
+     * @return array{commit: string, merged: bool, ref: string|null}[]
      *
      * @throws RuntimeException
      */

--- a/services/analyse/src/Service/History/CommitHistoryServiceInterface.php
+++ b/services/analyse/src/Service/History/CommitHistoryServiceInterface.php
@@ -11,7 +11,7 @@ interface CommitHistoryServiceInterface
     /**
      * Get the commits which preceded a given commit in the tree.
      *
-     * @return array{commit: string, isOnBaseRef: bool}[]
+     * @return array{commit: string, merged: bool, ref: string|null}[]
      */
     public function getPrecedingCommits(ReportWaypoint $waypoint, int $page): array;
 }

--- a/services/analyse/src/Service/History/Github/GithubCommitHistoryService.php
+++ b/services/analyse/src/Service/History/Github/GithubCommitHistoryService.php
@@ -45,7 +45,7 @@ class GithubCommitHistoryService implements CommitHistoryServiceInterface, Provi
     /**
      * @inheritDoc
      *
-     * @return array{commit: string, isOnBaseRef: bool}[]
+     * @return array{commit: string, merged: bool, ref: string|null}[]
      */
     public function getPrecedingCommits(EventInterface|ReportWaypoint $waypoint, int $page = 1): array
     {
@@ -78,7 +78,7 @@ class GithubCommitHistoryService implements CommitHistoryServiceInterface, Provi
     }
 
     /**
-     * @return array{commit: string, isOnBaseRef: bool}[]
+     * @return array{commit: string, merged: bool, ref: string|null}[]
      */
     private function getHistoricCommits(
         string $owner,
@@ -126,12 +126,8 @@ class GithubCommitHistoryService implements CommitHistoryServiceInterface, Provi
         return array_map(
             static fn(array $commit): array => [
                 'commit' => $commit['oid'],
-
-                // The commit _must_ be on the base ref (i.e. not in a PR) if theres no
-                // unmerged PRs, there was no PR to begin with (a direct push), or the only open
-                // PR is not on the same ref as we started on
-                'isOnBaseRef' => ($commit['associatedPullRequests']['nodes'][0]['merged'] ?? true) ||
-                    ($commit['associatedPullRequests']['nodes'][0]['headRefName'] ?? null) !== $ref
+                'merged' => $commit['associatedPullRequests']['nodes'][0]['merged'] ?? true,
+                'ref' => $commit['associatedPullRequests']['nodes'][0]['headRefName'] ?? null
             ],
             $result
         );

--- a/services/analyse/tests/Service/Carryforward/CarryforwardTagServiceTest.php
+++ b/services/analyse/tests/Service/Carryforward/CarryforwardTagServiceTest.php
@@ -107,17 +107,17 @@ class CarryforwardTagServiceTest extends TestCase
                         [
                             'commit' => 'mock-commit',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-2',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-3',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ]
                     ],
                     default => [],
@@ -173,23 +173,22 @@ class CarryforwardTagServiceTest extends TestCase
                 repository: 'mock-repository',
                 ref: 'mock-ref',
                 commit: 'mock-commit',
-                pullRequest: 3,
                 history: static fn(ReportWaypoint $waypoint, int $page) => match ($page) {
                     1 => [
                         [
                             'commit' => 'mock-commit',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-2',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-3',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         ...array_fill(
                             0,
@@ -197,7 +196,7 @@ class CarryforwardTagServiceTest extends TestCase
                             [
                                 'commit' => 'mock-commit-99',
                                 'ref' => 'non-main-branch',
-'merged' => false
+                                        'merged' => false
                             ]
                         )
                     ],
@@ -205,17 +204,17 @@ class CarryforwardTagServiceTest extends TestCase
                         [
                             'commit' => 'mock-commit-4',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-5',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-6',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ],
                         ...array_fill(
                             0,
@@ -223,7 +222,7 @@ class CarryforwardTagServiceTest extends TestCase
                             [
                                 'commit' => 'mock-commit-99',
                                 'ref' => 'non-main-branch',
-'merged' => false
+                                        'merged' => false
                             ]
                         )
                     ],
@@ -231,22 +230,23 @@ class CarryforwardTagServiceTest extends TestCase
                         [
                             'commit' => 'mock-commit-7',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-8',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-9',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ]
                     ],
                     default => [],
                 },
-                diff: []
+                diff: [],
+                pullRequest: 3
             ),
             []
         );
@@ -301,85 +301,85 @@ class CarryforwardTagServiceTest extends TestCase
                         [
                             'commit' => 'mock-commit',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-2',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-3',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ]
                     ],
                     2 => [
                         [
                             'commit' => 'mock-commit-4',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-5',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-6',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ]
                     ],
                     3 => [
                         [
                             'commit' => 'mock-commit-7',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-8',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-9',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ]
                     ],
                     4 => [
                         [
                             'commit' => 'mock-commit-10',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ],
                         [
                             'commit' => 'mock-commit-11',
                             'ref' => 'non-main-branch',
-'merged' => false
+                            'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-12',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ]
                     ],
                     5 => [
                         [
                             'commit' => 'mock-commit-13',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ],
                         [
                             'commit' => 'mock-commit-14',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ],
                         [
                             'commit' => 'mock-commit-15',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ]
                     ],
                     default => [],

--- a/services/analyse/tests/Service/Carryforward/CarryforwardTagServiceTest.php
+++ b/services/analyse/tests/Service/Carryforward/CarryforwardTagServiceTest.php
@@ -106,15 +106,18 @@ class CarryforwardTagServiceTest extends TestCase
                     1 => [
                         [
                             'commit' => 'mock-commit',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-2',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-3',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ]
                     ],
                     default => [],
@@ -175,59 +178,70 @@ class CarryforwardTagServiceTest extends TestCase
                     1 => [
                         [
                             'commit' => 'mock-commit',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-2',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-3',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         ...array_fill(
                             0,
                             CommitHistoryService::COMMITS_TO_RETURN_PER_PAGE - 3,
                             [
                                 'commit' => 'mock-commit-99',
-                                'isOnBaseRef' => false
+                                'ref' => 'non-main-branch',
+'merged' => false
                             ]
                         )
                     ],
                     2 => [
                         [
                             'commit' => 'mock-commit-4',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-5',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-6',
-                            'isOnBaseRef' => true
+                            'ref' => 'main-branch',
+'merged' => true
                         ],
                         ...array_fill(
                             0,
                             CommitHistoryService::COMMITS_TO_RETURN_PER_PAGE - 3,
                             [
                                 'commit' => 'mock-commit-99',
-                                'isOnBaseRef' => false
+                                'ref' => 'non-main-branch',
+'merged' => false
                             ]
                         )
                     ],
                     3 => [
                         [
                             'commit' => 'mock-commit-7',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-8',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-9',
-                            'isOnBaseRef' => true
+                            'ref' => 'main-branch',
+'merged' => true
                         ]
                     ],
                     default => [],
@@ -286,71 +300,86 @@ class CarryforwardTagServiceTest extends TestCase
                     1 => [
                         [
                             'commit' => 'mock-commit',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-2',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-3',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ]
                     ],
                     2 => [
                         [
                             'commit' => 'mock-commit-4',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-5',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-6',
-                            'isOnBaseRef' => true
+                            'ref' => 'main-branch',
+'merged' => true
                         ]
                     ],
                     3 => [
                         [
                             'commit' => 'mock-commit-7',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-8',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-9',
-                            'isOnBaseRef' => true
+                            'ref' => 'main-branch',
+'merged' => true
                         ]
                     ],
                     4 => [
                         [
                             'commit' => 'mock-commit-10',
-                            'isOnBaseRef' => true
+                            'ref' => 'main-branch',
+'merged' => true
                         ],
                         [
                             'commit' => 'mock-commit-11',
-                            'isOnBaseRef' => false
+                            'ref' => 'non-main-branch',
+'merged' => false
                         ],
                         [
                             'commit' => 'mock-commit-12',
-                            'isOnBaseRef' => true
+                            'ref' => 'main-branch',
+'merged' => true
                         ]
                     ],
                     5 => [
                         [
                             'commit' => 'mock-commit-13',
-                            'isOnBaseRef' => true
+                            'ref' => 'main-branch',
+'merged' => true
                         ],
                         [
                             'commit' => 'mock-commit-14',
-                            'isOnBaseRef' => true
+                            'ref' => 'main-branch',
+'merged' => true
                         ],
                         [
                             'commit' => 'mock-commit-15',
-                            'isOnBaseRef' => true
+                            'ref' => 'main-branch',
+'merged' => true
                         ]
                     ],
                     default => [],

--- a/services/analyse/tests/Service/Carryforward/CarryforwardTagServiceTest.php
+++ b/services/analyse/tests/Service/Carryforward/CarryforwardTagServiceTest.php
@@ -196,7 +196,7 @@ class CarryforwardTagServiceTest extends TestCase
                             [
                                 'commit' => 'mock-commit-99',
                                 'ref' => 'non-main-branch',
-                                        'merged' => false
+                                'merged' => false
                             ]
                         )
                     ],

--- a/services/analyse/tests/Service/Event/UploadsFinalisedEventProcessorTest.php
+++ b/services/analyse/tests/Service/Event/UploadsFinalisedEventProcessorTest.php
@@ -131,11 +131,13 @@ class UploadsFinalisedEventProcessorTest extends KernelTestCase
             history: [
                 [
                     'commit' => 'mock-commit',
-                    'isOnBaseRef' => false
+                    'ref' => 'mock-ref',
+                    'merged' => false
                 ],
                 [
                     'commit' => 'mock-parent-base-commit',
-                    'isOnBaseRef' => true
+                    'ref' => null,
+                    'merged' => true
                 ],
             ],
             diff: []

--- a/services/analyse/tests/Service/History/CachingCommitHistoryServiceTest.php
+++ b/services/analyse/tests/Service/History/CachingCommitHistoryServiceTest.php
@@ -24,7 +24,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                 [
                     'commit' => 'mock-commit-1',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ]
             ]);
 
@@ -39,7 +39,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                 [
                     'commit' => 'mock-commit-1',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ]
             ],
             $cachingCommitHistoryService->getPrecedingCommits($mockWaypoint, 1)
@@ -54,7 +54,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                 [
                     'commit' => 'mock-commit-1',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ]
             ],
             $cachingCommitHistoryService->getPrecedingCommits($mockWaypoint, 1)
@@ -76,7 +76,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                         [
                             'commit' => 'mock-commit-1',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ]
                     ]
                 ],
@@ -87,7 +87,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                         [
                             'commit' => 'mock-commit-2',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ]
                     ]
                 ]
@@ -104,7 +104,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                 [
                     'commit' => 'mock-commit-1',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ]
             ],
             $cachingCommitHistoryService->getPrecedingCommits($mockWaypoint, 1)
@@ -115,7 +115,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                 [
                     'commit' => 'mock-commit-2',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ]
             ],
             $cachingCommitHistoryService->getPrecedingCommits($mockWaypoint, 2)
@@ -149,7 +149,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                         [
                             'commit' => 'mock-commit-1',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ]
                     ]
                 ],
@@ -160,7 +160,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                         [
                             'commit' => 'mock-commit-2',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ]
                     ]
                 ]
@@ -177,7 +177,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                 [
                     'commit' => 'mock-commit-1',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ]
             ],
             $cachingCommitHistoryService->getPrecedingCommits($mockWaypointOne, 1)
@@ -188,7 +188,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                 [
                     'commit' => 'mock-commit-2',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ]
             ],
             $cachingCommitHistoryService->getPrecedingCommits($mockWaypointTwo, 1)
@@ -222,22 +222,22 @@ class CachingCommitHistoryServiceTest extends TestCase
                         [
                             'commit' => 'mock-commit-1',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ],
                         [
                             'commit' => 'mock-commit-2',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ],
                         [
                             'commit' => 'mock-commit-3',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ],
                         [
                             'commit' => 'mock-commit-4',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ],
                         ...array_fill(
                             0,
@@ -245,7 +245,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                             [
                                 'commit' => 'mock-commit-5',
                                 'ref' => 'main-branch',
-'merged' => true
+                                'merged' => true
                             ]
                         )
                     ],
@@ -257,7 +257,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                         [
                             'commit' => 'mock-commit-6',
                             'ref' => 'main-branch',
-'merged' => true
+                            'merged' => true
                         ]
                     ]
                 ]
@@ -274,22 +274,22 @@ class CachingCommitHistoryServiceTest extends TestCase
                 [
                     'commit' => 'mock-commit-1',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ],
                 [
                     'commit' => 'mock-commit-2',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ],
                 [
                     'commit' => 'mock-commit-3',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ],
                 [
                     'commit' => 'mock-commit-4',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ],
                 ...array_fill(
                     0,
@@ -297,7 +297,7 @@ class CachingCommitHistoryServiceTest extends TestCase
                     [
                         'commit' => 'mock-commit-5',
                         'ref' => 'main-branch',
-'merged' => true
+                        'merged' => true
                     ]
                 ),
             ],
@@ -309,12 +309,12 @@ class CachingCommitHistoryServiceTest extends TestCase
                 [
                     'commit' => 'mock-commit-3',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ],
                 [
                     'commit' => 'mock-commit-4',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ],
                 ...array_fill(
                     0,
@@ -322,16 +322,143 @@ class CachingCommitHistoryServiceTest extends TestCase
                     [
                         'commit' => 'mock-commit-5',
                         'ref' => 'main-branch',
-'merged' => true
+                        'merged' => true
                     ]
                 ),
                 [
                     'commit' => 'mock-commit-6',
                     'ref' => 'main-branch',
-'merged' => true
+                    'merged' => true
                 ]
             ],
             $cachingCommitHistoryService->getPrecedingCommits($mockWaypointTwo, 1)
+        );
+    }
+
+    public function testGetPrecedingCommitsCanUseComparableCommitsFromDifferentPagesAsOverlappingCache(): void
+    {
+        $mockWaypointOne = $this->getMockWaypoint();
+        $mockWaypointOne->method('getCommit')
+            ->willReturn('mock-commit-1');
+        $mockWaypointTwo = $this->getMockWaypoint();
+        $mockWaypointTwo->method('getCommit')
+            ->willReturn('mock-commit-4');
+
+        $mockWaypointOne->method('comparable')
+            ->with($mockWaypointTwo)
+            ->willReturn(true);
+        $mockWaypointTwo->method('comparable')
+            ->with($mockWaypointOne)
+            ->willReturn(true);
+
+        $mockParser = $this->createMock(CommitHistoryServiceInterface::class);
+        $mockParser->expects($this->exactly(2))
+            ->method('getPrecedingCommits')
+            ->willReturnMap([
+                [
+                    $mockWaypointOne,
+                    1,
+                    [
+                        [
+                            'commit' => 'mock-commit-1',
+                            'ref' => 'main-branch',
+                            'merged' => true
+                        ],
+                        [
+                            'commit' => 'mock-commit-2',
+                            'ref' => 'main-branch',
+                            'merged' => true
+                        ],
+                        [
+                            'commit' => 'mock-commit-3',
+                            'ref' => 'main-branch',
+                            'merged' => true
+                        ],
+                        [
+                            'commit' => 'mock-commit-4',
+                            'ref' => 'main-branch',
+                            'merged' => true
+                        ],
+                        ...array_fill(
+                            0,
+                            CommitHistoryService::COMMITS_TO_RETURN_PER_PAGE - 4,
+                            [
+                                'commit' => 'mock-commit-5',
+                                'ref' => 'main-branch',
+                                'merged' => true
+                            ]
+                        )
+                    ],
+                ],
+                [
+                    $mockWaypointTwo,
+                    2,
+                    array_fill(
+                        0,
+                        CommitHistoryService::COMMITS_TO_RETURN_PER_PAGE - 3,
+                        [
+                            'commit' => 'mock-commit-6',
+                            'ref' => 'main-branch',
+                            'merged' => true
+                        ]
+                    )
+                ],
+            ]);
+
+        $cachingCommitHistoryService = new CachingCommitHistoryService(
+            [
+                Provider::GITHUB->value => $mockParser
+            ]
+        );
+
+        $this->assertEquals(
+            [
+                [
+                    'commit' => 'mock-commit-1',
+                    'ref' => 'main-branch',
+                    'merged' => true
+                ],
+                [
+                    'commit' => 'mock-commit-2',
+                    'ref' => 'main-branch',
+                    'merged' => true
+                ],
+                [
+                    'commit' => 'mock-commit-3',
+                    'ref' => 'main-branch',
+                    'merged' => true
+                ],
+                [
+                    'commit' => 'mock-commit-4',
+                    'ref' => 'main-branch',
+                    'merged' => true
+                ],
+                ...array_fill(
+                    0,
+                    CommitHistoryService::COMMITS_TO_RETURN_PER_PAGE - 4,
+                    [
+                        'commit' => 'mock-commit-5',
+                        'ref' => 'main-branch',
+                        'merged' => true
+                    ]
+                ),
+            ],
+            $cachingCommitHistoryService->getPrecedingCommits($mockWaypointOne, 1)
+        );
+
+        $this->assertEquals(
+            [
+                ...array_fill(
+                    0,
+                    CommitHistoryService::COMMITS_TO_RETURN_PER_PAGE - 3,
+                    [
+                        'commit' => 'mock-commit-6',
+                        'ref' => 'main-branch',
+                        'merged' => true
+                    ]
+                )
+            ],
+            $cachingCommitHistoryService->getPrecedingCommits($mockWaypointTwo, 2)
         );
     }
 

--- a/services/analyse/tests/Service/History/CachingCommitHistoryServiceTest.php
+++ b/services/analyse/tests/Service/History/CachingCommitHistoryServiceTest.php
@@ -9,6 +9,7 @@ use App\Service\History\CommitHistoryServiceInterface;
 use Packages\Contracts\Provider\Provider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 class CachingCommitHistoryServiceTest extends TestCase
 {
@@ -31,7 +32,8 @@ class CachingCommitHistoryServiceTest extends TestCase
         $cachingCommitHistoryService = new CachingCommitHistoryService(
             [
                 Provider::GITHUB->value => $mockParser
-            ]
+            ],
+            new NullLogger()
         );
 
         $this->assertEquals(
@@ -96,7 +98,8 @@ class CachingCommitHistoryServiceTest extends TestCase
         $cachingCommitHistoryService = new CachingCommitHistoryService(
             [
                 Provider::GITHUB->value => $mockParser
-            ]
+            ],
+            new NullLogger()
         );
 
         $this->assertEquals(
@@ -169,7 +172,8 @@ class CachingCommitHistoryServiceTest extends TestCase
         $cachingCommitHistoryService = new CachingCommitHistoryService(
             [
                 Provider::GITHUB->value => $mockParser
-            ]
+            ],
+            new NullLogger()
         );
 
         $this->assertEquals(
@@ -266,7 +270,8 @@ class CachingCommitHistoryServiceTest extends TestCase
         $cachingCommitHistoryService = new CachingCommitHistoryService(
             [
                 Provider::GITHUB->value => $mockParser
-            ]
+            ],
+            new NullLogger()
         );
 
         $this->assertEquals(
@@ -408,7 +413,8 @@ class CachingCommitHistoryServiceTest extends TestCase
         $cachingCommitHistoryService = new CachingCommitHistoryService(
             [
                 Provider::GITHUB->value => $mockParser
-            ]
+            ],
+            new NullLogger()
         );
 
         $this->assertEquals(

--- a/services/analyse/tests/Service/History/Github/GithubCommitHistoryServiceTest.php
+++ b/services/analyse/tests/Service/History/Github/GithubCommitHistoryServiceTest.php
@@ -120,7 +120,7 @@ class GithubCommitHistoryServiceTest extends TestCase
                                 'nodes' => [
                                     [
                                         'merged' => false,
-                                        'headRefName' => 'mock-ref'
+                                        'headRefName' => 'mock-ref-2'
                                     ]
                                 ]
                             ]
@@ -135,7 +135,7 @@ class GithubCommitHistoryServiceTest extends TestCase
                                 'nodes' => [
                                     [
                                         'merged' => true,
-                                        'headRefName' => 'mock-ref-2'
+                                        'headRefName' => 'mock-ref'
                                     ]
                                 ]
                             ]
@@ -149,7 +149,8 @@ class GithubCommitHistoryServiceTest extends TestCase
                         50,
                         [
                             'commit' => '11111111',
-                            'isOnBaseRef' => false
+                            'merged' => false,
+                            'ref' => 'mock-ref-2'
                         ]
                     ),
                     ...array_fill(
@@ -157,10 +158,11 @@ class GithubCommitHistoryServiceTest extends TestCase
                         50,
                         [
                             'commit' => '11111111',
-                            'isOnBaseRef' => true
+                            'merged' => true,
+                            'ref' => 'mock-ref'
                         ]
                     )
-                ]
+                ],
             ],
             'Second page' => [
                 2,
@@ -198,7 +200,8 @@ class GithubCommitHistoryServiceTest extends TestCase
                         50,
                         [
                             'commit' => '222222222',
-                            'isOnBaseRef' => true
+                            'ref' => 'mock-ref',
+                            'merged' => true
                         ]
                     ),
                     ...array_fill(
@@ -206,7 +209,8 @@ class GithubCommitHistoryServiceTest extends TestCase
                         50,
                         [
                             'commit' => '222222222',
-                            'isOnBaseRef' => true
+                            'ref' => null,
+                            'merged' => true
                         ]
                     )
                 ]
@@ -214,21 +218,6 @@ class GithubCommitHistoryServiceTest extends TestCase
             'Tenth page' => [
                 10,
                 [
-                    ...array_fill(
-                        0,
-                        50,
-                        [
-                            'oid' => '9999999999',
-                            'associatedPullRequests' => [
-                                'nodes' => [
-                                    [
-                                        'merged' => false,
-                                        'headRefName' => 'mock-ref-2'
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ),
                     ...array_fill(
                         0,
                         50,
@@ -247,15 +236,8 @@ class GithubCommitHistoryServiceTest extends TestCase
                         50,
                         [
                             'commit' => '9999999999',
-                            'isOnBaseRef' => true
-                        ]
-                    ),
-                    ...array_fill(
-                        0,
-                        50,
-                        [
-                            'commit' => '9999999999',
-                            'isOnBaseRef' => true
+                            'ref' => null,
+                            'merged' => true
                         ]
                     )
                 ]


### PR DESCRIPTION
## Description