### PR TITLE
Explicitly specify the target branch when publishing split releases

### DIFF
--- a/.github/workflows/split-packages.yml
+++ b/.github/workflows/split-packages.yml
@@ -72,4 +72,4 @@ jobs:
 
             # Tags must be associated with a release for the private packages to pick up the available versions.
             - if: "startsWith(github.ref, 'refs/tags/')"
-              run: gh release create ${GITHUB_REF#refs/tags/} --repo "${{ matrix.package.organization }}/${{ matrix.package.repository }}" --notes "" --verify-tag --latest
+              run: gh release create ${GITHUB_REF#refs/tags/} --repo "${{ matrix.package.organization }}/${{ matrix.package.repository }}" --notes "" --target "main" --verify-tag --latest


### PR DESCRIPTION
## Description