### PR TITLE
Revert "Bump symplify/monorepo-split-github-action from 2.3.0 to 2.4.0 in the dependencies group"

### DIFF
--- a/.github/workflows/split-packages.yml
+++ b/.github/workflows/split-packages.yml
@@ -44,7 +44,7 @@ jobs:
 
             # When run on a tag push, the GITHUB_REF will be in the format refs/head/{commit_sha}
             - if: "!startsWith(github.ref, 'refs/tags/')"
-              uses: "symplify/monorepo-split-github-action@v2.4.0"
+              uses: "symplify/monorepo-split-github-action@v2.3.0"
               with:
                   # Split the package directory into the appropriate repository
                   package_directory: '${{ matrix.package.directory }}'
@@ -57,7 +57,7 @@ jobs:
 
             # When run on a tag push, the GITHUB_REF will be in the format refs/tags/{tag}
             - if: "startsWith(github.ref, 'refs/tags/')"
-              uses: "symplify/monorepo-split-github-action@v2.4.0"
+              uses: "symplify/monorepo-split-github-action@v2.3.0"
               with:
                   tag: ${GITHUB_REF#refs/tags/}
 


### PR DESCRIPTION
Reverts coverage-robot/core#2332